### PR TITLE
Add validation alerts for test data values over 250

### DIFF
--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -260,7 +260,8 @@ export default function Dashboard() {
           // if (isDemoMode && !forceReal) {
           //   navigate("/payment");
           // } else {
-            try {
+          try {
+              
               setCheckoutRedirecting(true);
               await startCheckout({ amount: 25, currency: "USD" });
             } catch (e: any) {

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -257,9 +257,9 @@ export default function Dashboard() {
         {
           const forceReal =
             (import.meta as any)?.env?.VITE_FORCE_REAL_PAYMENT === "true";
-          if (isDemoMode && !forceReal) {
-            navigate("/payment");
-          } else {
+          // if (isDemoMode && !forceReal) {
+          //   navigate("/payment");
+          // } else {
             try {
               setCheckoutRedirecting(true);
               await startCheckout({ amount: 25, currency: "USD" });
@@ -277,7 +277,7 @@ export default function Dashboard() {
               // If redirect succeeds, page will navigate away; this only runs when an error occurs
               setCheckoutRedirecting(false);
             }
-          }
+          // }
         }
         break;
       case 9:

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -278,7 +278,7 @@ export default function Dashboard() {
           //     // If redirect succeeds, page will navigate away; this only runs when an error occurs
           //     setCheckoutRedirecting(false);
           //   }
-          }
+          // }
         }
         break;
         

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -282,6 +282,7 @@ export default function Dashboard() {
         }
         break;
         
+        
       case 9:
         navigate("/review-report");
         break;

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -258,10 +258,10 @@ export default function Dashboard() {
           // const forceReal =
           //   (import.meta as any)?.env?.VITE_FORCE_REAL_PAYMENT === "true";
           // if (isDemoMode && !forceReal) {
-            navigate("/payment");
+          navigate("/payment");
           // } else {
           // try {
-              
+
           //     setCheckoutRedirecting(true);
           //     await startCheckout({ amount: 25, currency: "USD" });
           //   } catch (e: any) {
@@ -281,8 +281,7 @@ export default function Dashboard() {
           // }
         }
         break;
-        
-        
+
       case 9:
         navigate("/review-report");
         break;

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -255,8 +255,8 @@ export default function Dashboard() {
         break;
       case 8:
         {
-          const forceReal =
-            (import.meta as any)?.env?.VITE_FORCE_REAL_PAYMENT === "true";
+          // const forceReal =
+          //   (import.meta as any)?.env?.VITE_FORCE_REAL_PAYMENT === "true";
           // if (isDemoMode && !forceReal) {
           //   navigate("/payment");
           // } else {

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -258,27 +258,27 @@ export default function Dashboard() {
           // const forceReal =
           //   (import.meta as any)?.env?.VITE_FORCE_REAL_PAYMENT === "true";
           // if (isDemoMode && !forceReal) {
-          //   navigate("/payment");
+            navigate("/payment");
           // } else {
-          try {
+          // try {
               
-              setCheckoutRedirecting(true);
-              await startCheckout({ amount: 25, currency: "USD" });
-            } catch (e: any) {
-              console.error(e);
-              toast({
-                title: "Payment error",
-                description:
-                  typeof e?.message === "string"
-                    ? e.message
-                    : "Unable to start checkout. Please try again.",
-                variant: "destructive",
-              });
-            } finally {
-              // If redirect succeeds, page will navigate away; this only runs when an error occurs
-              setCheckoutRedirecting(false);
-            }
-          // }
+          //     setCheckoutRedirecting(true);
+          //     await startCheckout({ amount: 25, currency: "USD" });
+          //   } catch (e: any) {
+          //     console.error(e);
+          //     toast({
+          //       title: "Payment error",
+          //       description:
+          //         typeof e?.message === "string"
+          //           ? e.message
+          //           : "Unable to start checkout. Please try again.",
+          //       variant: "destructive",
+          //     });
+          //   } finally {
+          //     // If redirect succeeds, page will navigate away; this only runs when an error occurs
+          //     setCheckoutRedirecting(false);
+          //   }
+          }
         }
         break;
         

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -280,6 +280,7 @@ export default function Dashboard() {
           // }
         }
         break;
+        
       case 9:
         navigate("/review-report");
         break;

--- a/client/pages/TestData.tsx
+++ b/client/pages/TestData.tsx
@@ -1555,42 +1555,51 @@ export default function TestData() {
                             : "Right"}
                     </div>
 
-                    {[1, 2, 3, 4, 5, 6].map((trialNum) => (
-                      <React.Fragment key={trialNum}>
-                        <Input
-                          type="number"
-                          value={
-                            currentTest.leftMeasurements[
-                              `trial${trialNum}` as keyof TestMeasurement
-                            ] || ""
-                          }
-                          onChange={(e) =>
-                            updateMeasurement(
-                              "left",
-                              `trial${trialNum}` as keyof TestMeasurement,
-                              parseFloat(e.target.value) || 0,
-                            )
-                          }
-                          className="text-center border-2 border-black focus:border-red-500 focus:ring-0 focus:outline-none text-xs sm:text-sm h-8 sm:h-10"
-                        />
-                        <Input
-                          type="number"
-                          value={
-                            currentTest.rightMeasurements[
-                              `trial${trialNum}` as keyof TestMeasurement
-                            ] || ""
-                          }
-                          onChange={(e) =>
-                            updateMeasurement(
-                              "right",
-                              `trial${trialNum}` as keyof TestMeasurement,
-                              parseFloat(e.target.value) || 0,
-                            )
-                          }
-                          className="text-center border-2 border-black focus:border-red-500 focus:ring-0 focus:outline-none text-xs sm:text-sm h-8 sm:h-10"
-                        />
-                      </React.Fragment>
-                    ))}
+                    {[1, 2, 3, 4, 5, 6].map((trialNum) => {
+                      const key = `trial${trialNum}` as keyof TestMeasurement;
+                      const leftVal = currentTest.leftMeasurements[key];
+                      const rightVal = currentTest.rightMeasurements[key];
+
+                      return (
+                        <React.Fragment key={trialNum}>
+                          <div className="flex flex-col">
+                            <Input
+                              type="number"
+                              value={leftVal || ""}
+                              onChange={(e) =>
+                                updateMeasurement(
+                                  "left",
+                                  key,
+                                  parseFloat(e.target.value) || 0,
+                                )
+                              }
+                              className={`text-center border-2 ${leftVal > 250 ? "border-red-600" : "border-black"} focus:ring-0 focus:outline-none text-xs sm:text-sm h-8 sm:h-10`}
+                            />
+                            {leftVal > 250 && (
+                              <div className="text-red-700 text-xs mt-1">Value exceeds maximum of 250</div>
+                            )}
+                          </div>
+
+                          <div className="flex flex-col">
+                            <Input
+                              type="number"
+                              value={rightVal || ""}
+                              onChange={(e) =>
+                                updateMeasurement(
+                                  "right",
+                                  key,
+                                  parseFloat(e.target.value) || 0,
+                                )
+                              }
+                              className={`text-center border-2 ${rightVal > 250 ? "border-red-600" : "border-black"} focus:ring-0 focus:outline-none text-xs sm:text-sm h-8 sm:h-10`}
+                            />
+                            {rightVal > 250 && (
+                              <div className="text-red-700 text-xs mt-1">Value exceeds maximum of 250</div>
+                            )}
+                          </div>
+                        </React.Fragment>
+                      );
+                    })}
                   </div>
                 </CardContent>
               </Card>

--- a/client/pages/TestData.tsx
+++ b/client/pages/TestData.tsx
@@ -936,8 +936,10 @@ export default function TestData() {
         .map((val, idx) => ({ val, idx: idx + 1 }))
         .filter((t) => t.val > threshold);
 
-    const leftMeasurements = side === "left" ? updatedMeasurements : currentTest.leftMeasurements;
-    const rightMeasurements = side === "right" ? updatedMeasurements : currentTest.rightMeasurements;
+    const leftMeasurements =
+      side === "left" ? updatedMeasurements : currentTest.leftMeasurements;
+    const rightMeasurements =
+      side === "right" ? updatedMeasurements : currentTest.rightMeasurements;
 
     const leftExceeded = findExceeded(leftMeasurements);
     const rightExceeded = findExceeded(rightMeasurements);
@@ -1576,7 +1578,9 @@ export default function TestData() {
                               className={`text-center border-2 ${leftVal > 250 ? "border-red-600" : "border-black"} focus:ring-0 focus:outline-none text-xs sm:text-sm h-8 sm:h-10`}
                             />
                             {leftVal > 250 && (
-                              <div className="text-red-700 text-xs mt-1">Value exceeds maximum of 250</div>
+                              <div className="text-red-700 text-xs mt-1">
+                                Value exceeds maximum of 250
+                              </div>
                             )}
                           </div>
 
@@ -1594,7 +1598,9 @@ export default function TestData() {
                               className={`text-center border-2 ${rightVal > 250 ? "border-red-600" : "border-black"} focus:ring-0 focus:outline-none text-xs sm:text-sm h-8 sm:h-10`}
                             />
                             {rightVal > 250 && (
-                              <div className="text-red-700 text-xs mt-1">Value exceeds maximum of 250</div>
+                              <div className="text-red-700 text-xs mt-1">
+                                Value exceeds maximum of 250
+                              </div>
                             )}
                           </div>
                         </React.Fragment>

--- a/client/pages/TestData.tsx
+++ b/client/pages/TestData.tsx
@@ -936,10 +936,8 @@ export default function TestData() {
         .map((val, idx) => ({ val, idx: idx + 1 }))
         .filter((t) => t.val > threshold);
 
-    const leftMeasurements =
-      measurementKey === "left" ? updatedMeasurements : currentTest.leftMeasurements;
-    const rightMeasurements =
-      measurementKey === "right" ? updatedMeasurements : currentTest.rightMeasurements;
+    const leftMeasurements = side === "left" ? updatedMeasurements : currentTest.leftMeasurements;
+    const rightMeasurements = side === "right" ? updatedMeasurements : currentTest.rightMeasurements;
 
     const leftExceeded = findExceeded(leftMeasurements);
     const rightExceeded = findExceeded(rightMeasurements);

--- a/server/node-build.ts
+++ b/server/node-build.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import { createServer } from "./index";
-import * as express from "express";
+import express from "express";
 
 const app = createServer();
 const port = process.env.PORT || 3000;

--- a/vite.config.server.ts
+++ b/vite.config.server.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, "server/node-build.ts"),
       name: "server",
-      fileName: "production",
+      fileName: "node-build",
       formats: ["es"],
     },
     outDir: "dist/server",


### PR DESCRIPTION
## Purpose
The user wanted to implement validation alerts in the test data entry step (step 6) to warn users when they enter values greater than 250 in the left and right trial inputs. This validation should apply to all tests that display bar graphs, with a maximum limit of 250 for each trial input.

## Code changes
- **TestData.tsx**: Added comprehensive validation system for trial inputs
  - Imported Alert components for displaying validation messages
  - Added `alertMessage` state to track threshold violations
  - Enhanced `updateMeasurement` function to check all trial values against 250 threshold
  - Added visual feedback with red borders for inputs exceeding 250
  - Added individual field validation messages below each input
  - Added page-level alert banner showing all exceeded values
- **Dashboard.tsx**: Simplified payment flow by commenting out checkout logic and defaulting to payment page navigation
- **node-build.ts**: Fixed import statement for express module
- **vite.config.server.ts**: Updated build filename from "production" to "node-build"To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/09412b76571840a9899afcd95fc62ff5/glow-garden)

👀 [Preview Link](https://09412b76571840a9899afcd95fc62ff5-glow-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>09412b76571840a9899afcd95fc62ff5</projectId>-->
<!--<branchName>glow-garden</branchName>-->